### PR TITLE
Typecast escaped values for multiselect fields

### DIFF
--- a/cmb-field-select2.php
+++ b/cmb-field-select2.php
@@ -82,6 +82,9 @@ class PW_CMB2_Field_Select2 {
 	 */
 	public function get_pw_multiselect_options( $field_escaped_value = array(), $field_type_object ) {
 		$options = (array) $field_type_object->field->options();
+		
+		// When a single value leads to this variable being a string, cast it as an array
+		$field_escaped_value = (array) $field_escaped_value;
 
 		// If we have selected items, we need to preserve their order
 		if ( ! empty( $field_escaped_value ) ) {


### PR DESCRIPTION
[The 2.2.5.3 CMB2 update](v2.2.5.3) causes the function for getting and sorting the stored multiselect options to fail when only a single value is retrieved from the db - returning a string instead of the expected array. Typecasting in the helper function instead of the filter function might not be a proper solution, but it seems to work.